### PR TITLE
Update jupyterbook to allow for updated toc

### DIFF
--- a/BigData/_toc.yml
+++ b/BigData/_toc.yml
@@ -1,12 +1,23 @@
-# Table of content
-# Learn more at https://jupyterbook.org/customize/toc.html
-#
-- file: goals
-- file: data_storage
-  sections:
-  - file : nczarr_test
-- file: format_metadata
-- file: accessing_data
-- file: computations
-- file: different_tools.md
-- file: resources.md
+format: jb-book
+root: goals
+parts:
+  - caption: Storage methods for large datasets
+    chapters:
+    - file: data_storage
+      sections:
+      - file : nczarr_test
+  - caption: Data formats and metadata
+    chapters:
+    - file: format_metadata   
+  - caption: Methods of accessing data and metadata
+    chapters:
+    - file: accessing_data       
+  - caption: Computations with large datasets
+    chapters:
+    - file: computations     
+  - caption: Available tools
+    chapters:
+    - file: different_tools   
+  - caption: Resources
+    chapters:
+    - file: resources  

--- a/BigData/format_metadata.md
+++ b/BigData/format_metadata.md
@@ -35,4 +35,4 @@ The `ncview` tool, while very simple, can easily display netCDF data and highlig
 
 
 ### Metadata standards
-Link to Governance pages on this?
+Information about metadata standards and conventions can be found in the [Climate Data Guidelines](https://acdguide.github.io/Governance/concepts/conventions.html).

--- a/BigData/resources.md
+++ b/BigData/resources.md
@@ -2,7 +2,7 @@
 
 This page provides a list of resources related to working with large and challenging climate datasets. Brief descriptions and links to the resources are provided.
 
-## Documentation
+<details><summary><span style="font-size:xx-large;">Documentation</span></summary>
 
 | Name | Description |
 |-------|--------|
@@ -15,8 +15,10 @@ This page provides a list of resources related to working with large and challen
 | [CMS youtube](https://www.youtube.com/channel/UCSmoK6oWV9O0Hmyt9UdDNsQ) | Recorded presentations on climate analysis / model runs
 | [Xarray docs](http://xarray.pydata.org/en/stable/)| Python package for working with labelled, multi-dimensional arrays
 | [Dask docs](https://docs.dask.org/en/latest/)| Distributed computing
+</details>
 
-## Training
+<details><summary><span style="font-size:xx-large;">Training</span></summary>
+
 | Name | Description | Type |
 |------|-------------|------|
 |**CLEX Training** | ARC Centre of Excellence computing training sessions | [Videos](https://climateextremes.org.au/cms-videos/), [interactive notebooks](https://github.com/coecms-training), [youtube channel](https://www.youtube.com/user/COECSSCMS/videos)
@@ -26,15 +28,18 @@ This page provides a list of resources related to working with large and challen
 | **Intake-ESM -- Making It Easier To Consume Climate Data**	| By Anderson Banihirwe (NCAR)	| [Video screencast](https://www.youtube.com/watch?v=zjjpByZ0nOk)
 | **Research Software Engineering with Python** |	By Damien Irving et al	| [eBook](https://merely-useful.tech/py-rse/)
 |**Intro to Dask** |	In Pangeo Gallery	| [Notebook (interactive via Binder or noninteractive on website)](https://gallery.pangeo.io/repos/pangeo-data/pangeo-tutorial-gallery/dask.html)
+</details>
 
-## Example workflows
+<details><summary><span style="font-size:xx-large;">Example workflows</span></summary>
+
 | Name | Description | Type |
 |------|-------------|------|
 | [CLEX-CMS Blog](https://climate-cms.org) | | Blog posts (usually as non-interactive Jupyter notebooks) |
 | [Pangeo Gallery](https://protect-au.mimecast.com/s/mbKuCoVzE9HgZm7QuoDaec?domain=gallery.pangeo.io/) | Collections of notebooks with workflow examples; notebooks can be run interactively on Binder or viewed directly on the website | Website with links to notebooks | 
+</details>
 
+<details><summary><span style="font-size:xx-large;">Other resources</span></summary>
 
-## Miscellaneous
 | Name | Description | Type |
 |------|-------------|------|
 | [Tips for running Pangeo workflows on Australian HPC](https://github.com/csiro-dcfp/pangeo_hpc) | | Github repo with scripts and written advice

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jupyter-book == 0.10.*
+jupyter-book == 0.11.*
 matplotlib
 numpy
 ghp-import


### PR DESCRIPTION
The primary aspect of this PR is to update the `_toc.yml` file for cleaner formatting of the table of contents. The updated toc format requires `jupyter-book  = 0.11.*`, so I have also updated the `requirements.txt` file accordingly.

Other updates in this PR:
- add collapsible tables on resources page (was experimenting with options - if others prefer not having collapsible tables we can revert back)
- add link to Governance working group pages about metadata standards