### PR TITLE
Update "where to get help" page

### DIFF
--- a/BigData/help.md
+++ b/BigData/help.md
@@ -1,20 +1,38 @@
 # Where to get help
 
+## How to best ask for help
+A list of *where* to get help is provided below, but there are also some best practices when asking for help with software. While a lot of the rules of thumb listed here are for reporting a potential bug, they are also very applicable when asking for help. If you use this advice, you are also more likely to get a quick response! 
+
+**Rules of thumb** (note that for general usage questions, these may not apply):
+
+- Include a minimal, complete, reproducible example of the code that is creating an error. (Also called a minimal, complete, verifiable example.)
+    - Minimal: trim extra lines of code that don't contribute to the error
+    - Complete: make sure all the necessary information needed to reproduce the error is included.
+    - Reproducible: ensure that the error you get can be reproduced with the minimal, complete lines of code that you provide.
+        - More details on creating minimal, complete, reproducible code: https://stackoverflow.com/help/minimal-reproducible-example and http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports.
+- When including code that leads to an error, make it copy/pasteable (i.e. do not include code as an image).
+- Create the data you need within your example; i.e. don't use data that needs to be downloaded or is not publicly accessible. If communicating with someone at your own institution (e.g. at NCI), then they may have access to your dataset, but in general it's a good habit to create some "dummy" data that can recreate your error if possible.
+
 ## Australia-specific help channels
 | Name | Description | How to use |
 |------|-------------|------|
-|[CLEX-CMS wiki](http://climate-cms.wikis.unsw.edu.au/Home) | Lots of info/links from Computation Modelling Systems team at the Climate Extremes ARC Centre of Excellence | Browse content on you rown
+|[CLEX-CMS wiki](http://climate-cms.wikis.unsw.edu.au/Home) | Lots of info/links from Computation Modelling Systems team at the Climate Extremes ARC Centre of Excellence | Browse content on your own
 | ARCCSS Slack workspace | Slack workspace open to anyone in the Australian climate community | Ask/answer questions via chat
-| BoM Data Science CoP | Community of data scientsists at BoM | ? |
+| BoM Data Science Community of Practice | Community of data scientsists at BoM | ? |
 | [COSIMA Recipes](https://github.com/COSIMA/cosima-recipes) | GitHub repo with example notebooks relevant for ACCESS-OM2 models | Browse on your own |
 | CSC Data Science Network | Community of data scientists in CSIRO's climate science centre | CSIRO MS Teams group - request membership from Chloe Mackallah or Claire Trenham |
 
 ## Global help channels
-- search for help pages specific to packages/languages
-- Stackoverflow
+- Search for help pages specific to packages/languages
+    - Xarray-specific: 
+        - [Xarray Discussions](https://github.com/pydata/xarray/discussions): for Q&A with Xarray developers and other community members. This is a great place to ask general usage questions.
+    - Dask-specific:
+        - [Dask Community page](https://docs.dask.org/en/stable/support.html): this site contains a list of 5 different platforms where Dask users can get help, with explanations for which one to use depending on the help you need.
+- [Stackoverflow](https://stackoverflow.com)
 - Pangeo [Discourse](https://discourse.pangeo.io/) Forum
-- GitHub - reach out to developers
-- topic-specific Slack workspaces (e.g. Dask, RSE)
+- [GitHub](https://github.com) - reach out to developers
+- Topic-specific Slack workspaces (e.g. Dask, RSE)
+- Use Google! Or your favorite search engine! (This is especially helpful when you get an unkown error while coding.)
 
 ### Take a look at this flowchart to help you figure out where to get help depending on your problem 
 (created by Dougie Squire)

--- a/BigData/intro.md
+++ b/BigData/intro.md
@@ -1,4 +1,4 @@
-# Welcome to the Australian Climate Data Guide: Working with Big/Challenging Data Collections
+# Overview
 
 This Jupyter Book is a compilation of resources and best practices for climate scientists in Australia who work with big/challenging datasets. This book is intended for both dataset creators and dataset users. While the focus is on Australian climate scientists, many of the resources listed here are generally applicable.
 


### PR DESCRIPTION
This PR has several updates to the help page, particularly the addition of some "best practices" (e.g. how to create minimal, reproducible examples of code).

This PR also updates the name of the landing page to "Overview". Previously it just listed the title of our working group, which just made it look like a title instead of a clickable overview of what the book is. Open to other suggestions for wording here!

Resolves #9 